### PR TITLE
fix マイグレーション。posts テーブルの作成で、id を integer に変更、email がユニークになるようインデックスを追加。

### DIFF
--- a/Config/Migration/1469262935_create_users_table.php
+++ b/Config/Migration/1469262935_create_users_table.php
@@ -18,7 +18,7 @@ class CreateUsersTable extends CakeMigration {
 			'create_table' => array(
     			'users' => array(
         			'id' => array(
-            			'type'    =>'string',
+            			'type'    =>'integer',
             			'null'    => false,
             			'default' => null,
             			'key'     => 'primary'
@@ -48,11 +48,15 @@ class CreateUsersTable extends CakeMigration {
             			'null'    => false,
             			'default' => null
         			),
-        			'index' => array(
+        			'indexes' => array(
             			'PRIMARY' => array(
         	        		'column' => 'id',
             	    		'unique' => 1
             			),
+                        'EMAIL' => array(
+        	        		'column' => 'email',
+            	    		'unique' => 1
+                        ),
         			),
     			),
 			),


### PR DESCRIPTION
マージリクエスト。

この修正をマージしたら、
一旦 `Console/cake migrations.migration run reset` を実行して、テーブルをクリアしてから、
再度 `Console/cake migrations.migration run all` してマイグレーションをやり直して下さい。
テーブルに入っているデータは消えてしまうのでご注意ください。
